### PR TITLE
#46104 Basic desktop2 engine

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -8,8 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import json
+import functools
+
 from sgtk.platform import Engine
 import sgtk
+from tank_vendor.shotgun_authentication import ShotgunAuthenticator
 
 logger = sgtk.LogManager.get_logger(__name__)
 
@@ -35,6 +39,67 @@ class DesktopEngine2(Engine):
         # hack to get this to work due to weird error checks in py console...
         sgtk.platform.engine.g_current_engine = self
         self.commands["Shotgun Python Console..."]["callback"]()
+
+        # We need to initialize current login
+        # We know for sure there is a default user, since either the migration was done
+        # or we logged in as an actual user with the new installer.
+        human_user = ShotgunAuthenticator(
+            # We don't want to get the script user, but the human user, so tell the
+            # CoreDefaultsManager manager that we are not interested in the script user. Do not use
+            # the regular shotgun_authentication.DefaultsManager to get this user because it will
+            # not know about proxy information.
+            sgtk.util.CoreDefaultsManager(mask_script_user=True)
+        ).get_default_user()
+        # Cache the user so we can refresh the credentials before launching a background process
+        self._user = human_user
+        # Retrieve the current logged in user information. This will be used when creating
+        # event log entries.
+        self._current_login = self.sgtk.shotgun.find_one(
+            "HumanUser",
+            [["login", "is", human_user.login]],
+            ["id", "login"]
+        )
+
+        # import and keep a handle on the bundled python module
+        self.__tk_desktop2 = self.import_module("tk_desktop2")
+        self.__desktopserver = self.__tk_desktop2.desktopserver
+        # self.__desktopserver.launch_desktop_server(
+        #     self._user.host,
+        #     self._current_login["id"],
+        #     parent=None,
+        # )
+
+        from PySide2 import QtCore, QtNetwork, QtWebSockets
+        self._server = QtWebSockets.QWebSocketServer(
+            "toolkit",
+            QtWebSockets.QWebSocketServer.NonSecureMode,
+        )
+        self._server.listen(QtNetwork.QHostAddress("ws://localhost"), 9000)
+        self._server.newConnection.connect(self._on_new_connection)
+
+    def _on_new_connection(self):
+        """
+
+        """
+        ws = self._server.nextPendingConnection()
+        self.logger.debug("New connection received: %r", ws)
+        ws.disconnected.connect(functools.partial(self._on_disconnect, ws))
+        ws.textMessageReceived.connect(functools.partial(self._on_message_received, ws))
+
+    def _on_disconnect(self, ws):
+        """
+
+        """
+        self.logger.debug("Websocket connection closed: %r", ws)
+
+    def _on_message_received(self, ws, message):
+        """
+
+        """
+        self.logger.debug("Message received: %s", message)
+        if message == "get_protocol_version":
+            self.logger.debug("Replying with protocol version 2.")
+            ws.sendTextMessage(json.dumps(dict(protocol_version=2)))
 
     def _get_dialog_parent(self):
         """

--- a/info.yml
+++ b/info.yml
@@ -25,3 +25,6 @@ description: "Shotgun Support in Shotgun Desktop v2"
 requires_shotgun_version:
 requires_core_version: "v0.18.116"
 
+frameworks:
+  - {"name": "tk-framework-desktopserver", "version": "v1.x.x"}
+

--- a/python/tk_desktop2/__init__.py
+++ b/python/tk_desktop2/__init__.py
@@ -8,3 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import sgtk
+
+desktopserver = sgtk.platform.get_framework("tk-framework-desktopserver")


### PR DESCRIPTION
First steps for a desktop2 engine. This is mainly spike-type work but contains some work in progress parenting code, showing how to retrieve the qml engine object via pyside and from there getting the main window.