### PR TITLE
SG-10799: User name comparisons are now case insensitive.

### DIFF
--- a/python/tk_desktop2/websockets/websockets_server.py
+++ b/python/tk_desktop2/websockets/websockets_server.py
@@ -177,7 +177,12 @@ class WebsocketsServer(object):
         logger.debug("Shotgun site user: %s", user_name)
         logger.debug("Shotgun Create user: %s", current_user)
 
-        if current_user != user_name:
+        # We're forcing lowercase here because we ran into an issue on Windows 7
+        # where it's possible that a user can login with different casing and it
+        # will be maintained. That would cause a problem here if we ended up
+        # trying to compare "Jeff" with "jeff", even though they're technically
+        # the same user as far as we care here.
+        if current_user.lower() != user_name.lower():
             warning_msg = (
                 "A request was received from Shotgun from user %s. Shotgun "
                 "Create is currently authenticated with user %s, so the "


### PR DESCRIPTION
When comparing the currently-logged-in user against the user requesting menu actions via browser integration, we now make sure we're doing so in a case insensitive manner. Prior to this fix, we saw issues on Windows 7 where a user might accidentally log in with mixed casing and cause a false negative that resulted in browser integration being denied.