### PR TITLE
SG-13074: Adds telemetry to websocket calls

### DIFF
--- a/python/tk_desktop2/websockets/requests/deferred_request.py
+++ b/python/tk_desktop2/websockets/requests/deferred_request.py
@@ -64,6 +64,13 @@ class DeferredRequest(object):
         """
         return self._request.linked_entity_type
 
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics or None if no value should be logged.
+        """
+        return self._request.analytics_command_name
+
     def can_be_executed(self):
         """
         True if the request is ready to be executed, false if not

--- a/python/tk_desktop2/websockets/requests/local_file_linking/open_file.py
+++ b/python/tk_desktop2/websockets/requests/local_file_linking/open_file.py
@@ -70,6 +70,13 @@ class OpenFileWebsocketsRequest(WebsocketsRequest):
 
         self._path = parameters["filepath"]
 
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "local_file_linking_open_file"
+
     def _execute(self):
         """
         Execute payload in a separate thread.

--- a/python/tk_desktop2/websockets/requests/local_file_linking/pick_file.py
+++ b/python/tk_desktop2/websockets/requests/local_file_linking/pick_file.py
@@ -83,6 +83,12 @@ class PickFilesOrDirectoriesWebsocketsRequest(PickFileOrFilesWebsocketsRequest):
             pick_multiple=True
         )
 
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "local_file_linking_pick_multiple_files"
 
 class PickFileOrDirectoryWebsocketsRequest(PickFileOrFilesWebsocketsRequest):
     """
@@ -113,3 +119,10 @@ class PickFileOrDirectoryWebsocketsRequest(PickFileOrFilesWebsocketsRequest):
             id, 
             pick_multiple=False
         )
+
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "local_file_linking_pick_single_file"

--- a/python/tk_desktop2/websockets/requests/request.py
+++ b/python/tk_desktop2/websockets/requests/request.py
@@ -106,6 +106,13 @@ class WebsocketsRequest(object):
         return None
 
     @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics or None if no value should be logged.
+        """
+        return None
+
+    @property
     def linked_entity_type(self):
         """
         Linked entity type associated with this request or None if not applicable.

--- a/python/tk_desktop2/websockets/requests/request_runner.py
+++ b/python/tk_desktop2/websockets/requests/request_runner.py
@@ -73,6 +73,14 @@ class RequestRunner(QtCore.QObject):
 
         :param request: :class:`WebsocketsRequest` instance to execute.
         """
+        # log analytics
+        if request.analytics_command_name:
+            bundle = sgtk.platform.current_bundle()
+            bundle.log_metric(
+                "Executed websockets command", 
+                command_name=request.analytics_command_name
+            )
+
         if not request.requires_toolkit:
             # no toolkit context needed. Action straight away.
             request.execute()

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
@@ -52,6 +52,13 @@ class OpenTaskInSGCreateWebsocketsRequest(WebsocketsRequest):
         else:
             self._version_id = None
 
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "open_create_task"
+
     def execute(self):
         """
         Execute the payload of the command

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_task_board.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_task_board.py
@@ -54,6 +54,13 @@ class OpenTaskBoardInSGCreateWebsocketsRequest(WebsocketsRequest):
         else:
             self._task_id = parameters["task_id"]
         
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "open_create_task_board"
+
     def execute(self):
         """
         Execute the payload of the command

--- a/python/tk_desktop2/websockets/requests/toolkit_actions/execute_action.py
+++ b/python/tk_desktop2/websockets/requests/toolkit_actions/execute_action.py
@@ -123,6 +123,13 @@ class ExecuteActionWebsocketsRequest(WebsocketsRequest):
             self._project_id = parameters["project_id"]
 
     @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "execute_toolkit_action"
+
+    @property
     def requires_toolkit(self):
         """
         True if the request requires toolkit


### PR DESCRIPTION
Adds new analytics calls so that when a subset of websockets calls are executed, these events are logged. The metric will be logged as `Executed websockets command` and applies to 

- Local file linking - open (attribute `local_file_linking_open_file`)
- Local file linking - browse (attributes `local_file_linking_pick_multiple_files`, `local_file_linking_pick_single_file`)
- Open task in SG Create (attribute `open_create_task`)
- Open task board in SG create (attribute `open_create_task_board`)
- Launch TK action (attribute `execute_toolkit_action`)