### PR TITLE
Allows websocket calls throught shotgunlocalhost

### DIFF
--- a/python/tk_desktop2/websockets/websockets_connection.py
+++ b/python/tk_desktop2/websockets/websockets_connection.py
@@ -40,9 +40,9 @@ class WebsocketsConnection(object):
     _legacy_site_warning_displayed = False
     _legacy_user_warning_displayed = False
 
-    # localhost url regex matcher
-    # https://regex101.com/r/OeTZRx/4
-    localhost_re = re.compile(r"^(?:[A-Za-z]+://)?(?:(?:shotgunlocalhost\.com)|(?:localhost))(?::\d+)?(?:/\S*)*$")
+    # Pre-compiled shotgunlocalhost.com/localhost regex matcher
+    # You can play with it here: https://regex101.com/r/7n3JIp/3
+    localhost_re = re.compile(r"^https?://(?:shotgunlocalhost\.com|localhost):[0-9]{1,5}$")
 
     def __init__(self, socket_id, origin_site, encryption_handler, server_wrapper):
         """

--- a/python/tk_desktop2/websockets/websockets_connection.py
+++ b/python/tk_desktop2/websockets/websockets_connection.py
@@ -7,6 +7,7 @@
 import sgtk
 import pprint
 import datetime
+import re
 from . import util
 from . import requests
 from . import constants
@@ -38,6 +39,10 @@ class WebsocketsConnection(object):
     # handle legacy ui popups for site/user mismatch
     _legacy_site_warning_displayed = False
     _legacy_user_warning_displayed = False
+
+    # localhost url regex matcher
+    # https://regex101.com/r/OeTZRx/4
+    localhost_re = re.compile(r"^(?:[A-Za-z]+://)?(?:(?:shotgunlocalhost\.com)|(?:localhost))(?::\d+)?(?:/\S*)*$")
 
     def __init__(self, socket_id, origin_site, encryption_handler, server_wrapper):
         """
@@ -186,9 +191,9 @@ class WebsocketsConnection(object):
                 "Unexpected error while trying to retrieve the user id: "
                 "No user information was found in this request."
             )
-
-        # validate that the site of the request matches the sg create site
-        if self._origin_site != self._bundle.sgtk.shotgun_url:
+        
+        # validate that the site of the request matches shotgunlocalhost.com or the sg create site
+        if not WebsocketsConnection.localhost_re.match(self._origin_site) and self._origin_site != self._bundle.sgtk.shotgun_url:
             if shotgun_version < constants.SHOTGUN_VERSION_SUPPORTING_ERROR_STATES:
                 # pop up UI once
                 if not WebsocketsConnection._legacy_site_warning_displayed:
@@ -338,3 +343,4 @@ class WebsocketsConnection(object):
             )
             data = {"retcode": -1, "out": "", "err": str(e)}
             self.reply(data, message_obj["id"])
+


### PR DESCRIPTION
In order to be able to send requests to Shotgun Create from a local tool, we
need to allow communications comming from localhost.

With these changes, a local process can talk to create using
"wss://shotgunlocalhost.com:PORT"