### PR TITLE
Add a set_media_path command to the ws server

### DIFF
--- a/python/tk_desktop2/websockets/requests/commands.py
+++ b/python/tk_desktop2/websockets/requests/commands.py
@@ -23,6 +23,7 @@ def get_supported_commands():
     from .toolkit_actions import GetActionsWebsocketsRequest
     from .sgc_actions import OpenTaskInSGCreateWebsocketsRequest
     from .sgc_actions import OpenTaskBoardInSGCreateWebsocketsRequest
+    from .sgc_actions import SetMediaPathInSGCreateWebsocketsRequest
     from .list_commands import ListSupportedCommandsWebsocketsRequest
 
     # supported commands
@@ -39,6 +40,7 @@ def get_supported_commands():
         # shotgun Create integration
         "sgc_open_task": {"class": OpenTaskInSGCreateWebsocketsRequest},
         "sgc_open_task_board": {"class": OpenTaskBoardInSGCreateWebsocketsRequest},
+        "set_media_path": {"class": SetMediaPathInSGCreateWebsocketsRequest}
     }
 
     return commands

--- a/python/tk_desktop2/websockets/requests/sgc_actions/__init__.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/__init__.py
@@ -7,4 +7,4 @@
 
 from .open_task import OpenTaskInSGCreateWebsocketsRequest
 from .open_task_board import OpenTaskBoardInSGCreateWebsocketsRequest
-
+from .set_media_path import SetMediaPathInSGCreateWebsocketsRequest

--- a/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
@@ -13,11 +13,11 @@ logger = sgtk.LogManager.get_logger(__name__)
 
 class SetMediaPathInSGCreateWebsocketsRequest(WebsocketsRequest):
     """
-    Requests that set the current media in the Shotgun Create player.
+    Requests that sets the current media in the Shotgun Create player.
 
     This is a 'fire-and-forget' command that doesn't return anything.
 
-    Parameters dictionary is expected to be on the following form:
+    Parameters dictionary is expected to be of the following form:
 
     {
         'path': "/path/to/a/file/to/load"
@@ -37,7 +37,6 @@ class SetMediaPathInSGCreateWebsocketsRequest(WebsocketsRequest):
 
         self._bundle = sgtk.platform.current_bundle()
 
-        # validate
         if "path" not in parameters:
             raise ValueError(
                 "%s: Missing required 'path' key "

--- a/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
@@ -1,0 +1,72 @@
+# Copyright 2018 Autodesk, Inc.  All rights reserved.
+#
+# Use of this software is subject to the terms of the Autodesk license agreement
+# provided at the time of installation or download, or which otherwise accompanies
+# this software in either electronic or hard copy form.
+#
+
+import sgtk
+from ..request import WebsocketsRequest
+from ....shotgun_entity_path import ShotgunEntityPath
+
+logger = sgtk.LogManager.get_logger(__name__)
+
+
+class SetMediaPathInSGCreateWebsocketsRequest(WebsocketsRequest):
+    """
+    Requests that set the current media in the Shotgun Create player.
+
+    This is a 'fire-and-forget' command that doesn't return anything.
+
+    Parameters dictionary is expected to be on the following form:
+
+    {
+        'path': "/path/to/a/file/to/load"
+    }
+
+    - path is required and needs to point to a valid path on disk.
+    """
+
+    def __init__(self, connection, id, parameters):
+        """
+        :param connection: Associated :class:`WebsocketsConnection`.
+        :param int id: Id for this request.
+        :param dict params: Parameters payload from websockets.
+        """
+        super(SetMediaPathInSGCreateWebsocketsRequest,
+              self).__init__(connection, id)
+
+        self._bundle = sgtk.platform.current_bundle()
+
+        # validate
+        if "path" not in parameters:
+            raise ValueError(
+                "%s: Missing required 'path' key "
+                "in parameter payload %s" % (self, parameters)
+            )
+
+        self._media_path = parameters["path"]
+
+    @property
+    def analytics_command_name(self):
+        """
+        The command name to pass to analytics.
+        """
+        return "set_media_path"
+
+    def execute(self):
+        """
+        Execute the payload of the command
+        """
+        try:
+            # call out to Shotgun Create UI to set the media path
+            self._bundle.toolkit_manager.emitSetMediaPath(
+                self._media_path
+            )
+        except Exception as e:
+            self._reply_with_status(
+                status=1,
+                error=str(e)
+            )
+        else:
+            self._reply_with_status(0)

--- a/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/set_media_path.py
@@ -7,7 +7,6 @@
 
 import sgtk
 from ..request import WebsocketsRequest
-from ....shotgun_entity_path import ShotgunEntityPath
 
 logger = sgtk.LogManager.get_logger(__name__)
 


### PR DESCRIPTION
JIRA: VMR-2452

DESCRIPTION

Add a set_media_path { "path": "/path/to/media" } command to the websocket
server so the websocket server can control what is shown in the TaskView's
player.