### PR TITLE
Append the CA Bundle to the server certificate.

### DIFF
--- a/python/tk_desktop2/websockets/shotgun_cert_handler.py
+++ b/python/tk_desktop2/websockets/shotgun_cert_handler.py
@@ -29,7 +29,8 @@ class ShotgunCertificateHandler(object):
 
         # ensure we support this
         if not self._site_supports_shotgunlocalhost():
-            raise ShotgunLocalHostCertNotSupportedError("Shotgun site does not support Certificate download.")
+            raise ShotgunLocalHostCertNotSupportedError(
+                "Shotgun site does not support Certificate download.")
 
         # ensure we have fresh certs
         self._retrieve_certificates_from_shotgun()
@@ -54,7 +55,8 @@ class ShotgunCertificateHandler(object):
         """
         logger.debug("Retrieving certificates from Shotgun")
         certs = self._bundle.shotgun._call_rpc("sg_desktop_certificates", {})
-        self._write_cert(self.cert_path, certs["sg_desktop_cert"])
+        self._write_cert(
+            self.cert_path, certs["sg_desktop_cert"] + "\n" + certs["sg_desktop_ca"])
         self._write_cert(self.key_path, certs["sg_desktop_key"])
 
     def _get_shotgunlocalhost_keys_folder(self):


### PR DESCRIPTION
JIRA: VMR-2452

DESCRIPTION

Append the bundle tot the certifiicate so clients doesn't have to
rely on certificate discovery to resolve the certificate chain.