### PR TITLE
Always inject the current interpreter path in the ExternalCommands

### DIFF
--- a/python/tk_desktop2/action_handler.py
+++ b/python/tk_desktop2/action_handler.py
@@ -445,6 +445,11 @@ class ActionHandler(object):
                     command.display_name,
                 )
 
+            # Inject the engine's interpreter in the command.
+            command._interpreter = (
+                sgtk.platform.current_engine().python_interpreter_path
+            )
+
             # This is addressing a pretty extreme edge case, but if there are multiple
             # PC entities for the project referencing the exact same config on disk,
             # we end up with duplicate actions equal to the number of PC entities sharing


### PR DESCRIPTION
Shotgun Create's location change every time there's an update. 

The python interpreter set in `interpreter_<os>.cfg` get out of sync at the first update (because the python interpreter is in the Shotgun Create application bundle) so we can't rely on it to run the external commands. 

I'm not sure of the implications of this fix. It unblocked my issues, but I don't know if the real solution is to fix it somewhere deeper. I need the inputs from someone who know better about this part of toolkit.