### PR TITLE
VMR-2799: Updates the interpreter paths cached into external commands

### DIFF
--- a/python/tk_desktop2/action_handler.py
+++ b/python/tk_desktop2/action_handler.py
@@ -294,8 +294,18 @@ class ActionHandler(object):
         # Cache the configs!
         self._cached_configs[project_id] = configs
 
+        logger.debug(
+            "Config interpreter paths will be updated to: %s",
+            self._bundle.python_interpreter_path
+        )
+
         # wire up signals from our cached command objects
         for config in configs:
+            # SG Create's Python interpreter path changes when the application is updated.
+            # We need to make sure the interpreter referenced by the config object is
+            # current, because it might have been cached to disk prior to the most recent
+            # update of Create.
+            config.interpreter = self._bundle.python_interpreter_path
             config.commands_loaded.connect(self._on_commands_loaded)
             config.commands_load_failed.connect(self._on_commands_load_failed)
 
@@ -444,7 +454,7 @@ class ActionHandler(object):
             #
             # NOTE: we know there's an underlying problem here and that we have more
             # work to do in the future before we can bake Create's Python interpreter
-            # into advanced config setups. Because it changes during update, the
+            # into advanced config setups. Because it changes during an update, the
             # path referenced in a config will also have to update along with it. We
             # have the beginnings of a plan in place where we will reference a manifest
             # that directs us to a Python interpreter path that is current, and we'll

--- a/python/tk_desktop2/action_handler.py
+++ b/python/tk_desktop2/action_handler.py
@@ -428,6 +428,11 @@ class ActionHandler(object):
         # TODO: This will need revisiting once we have final designs.
         SYSTEM_COMMANDS = ["Toggle Debug Logging", "Open Log Folder"]
 
+        logger.debug(
+            "Command interpreter paths will be updated to: %s",
+            self._bundle.python_interpreter_path
+        )
+
         for command in commands:
 
             if command.display_name in SYSTEM_COMMANDS:

--- a/python/tk_desktop2/websockets/requests/request_runner.py
+++ b/python/tk_desktop2/websockets/requests/request_runner.py
@@ -192,8 +192,17 @@ class RequestRunner(QtCore.QObject):
         # cache our configs
         self._cached_configs[project_id] = configs
 
+        logger.debug(
+            "Config interpreter paths will be updated to: %s",
+            self._bundle.python_interpreter_path
+        )
+
         # wire up signals from our cached command objects
         for config in configs:
+            # SG Create's Python interpreter path changes after the application is updated.
+            # we need to ensure that our path isn't stale, as it might have been cached
+            # to disk before the most recent update.
+            config.interpreter = self._bundle.python_interpreter_path
             config.commands_loaded.connect(self._on_commands_loaded)
             config.commands_load_failed.connect(self._on_commands_load_failed)
 


### PR DESCRIPTION
We know that SG Create's Python interpreter path changes when an update occurs, so we shouldn't assume that any commands we've loaded from disk are going to have the correct interpreter path.

This is an interim workaround fix, though it's clean. We know we have more work to do in the future regarding these changing interpreter paths and how that will impact advanced Toolkit configurations, but that's not a problem we need to resolve right now. That work will be tackled more thoroughly once we're farther along towards exposing a project setup wizard for Toolkit from Create.