### PR TITLE
Make list_commands Python3 compatible

### DIFF
--- a/python/tk_desktop2/websockets/requests/list_commands.py
+++ b/python/tk_desktop2/websockets/requests/list_commands.py
@@ -36,4 +36,4 @@ class ListSupportedCommandsWebsocketsRequest(WebsocketsRequest):
         Command execution.
         """
         commands = get_supported_commands()
-        self._reply(commands.keys())
+        self._reply(list(commands.keys()))


### PR DESCRIPTION
Without this change, a call to the `list_commands` request would return
```
 {"ws_server_id": "ABC123==", "timestamp": "2020-05-13T10:57:10.267121", "protocol_version": 2, "id": 2, "reply": {"retcode": -1, "out": "", "err": "Object of type dict_keys is not JSON serializable"}}
```

And it's because `keys()` from a dict instance returns a list in python2 and
a an object that is not serializable `json.dumps()`.