### PR TITLE
Do not automatically set the log manager to debug

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -44,9 +44,7 @@ class DesktopEngine2(Engine):
         """
         Initialization that runs after all apps and the QT abstractions have been loaded.
         """
-        from sgtk import LogManager
-
-        LogManager().global_debug = True
+        pass
 
     @property
     def toolkit_manager(self):


### PR DESCRIPTION
This was set for testing purposes and was supposed to be removed before merging.