### PR TITLE
Open Tasks and Versions without entities

### DIFF
--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
@@ -109,7 +109,7 @@ class OpenTaskInSGCreateWebsocketsRequest(WebsocketsRequest):
                 version_path.set_project(version_data["project"]["id"])
                 if version_data["entity"] is None:
                     version_path.set_primary_entity("Version", self._version_id)
-                else :
+                else:
                     version_path.set_primary_entity(
                         version_data["entity"]["type"], version_data["entity"]["id"]
                     )

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
@@ -76,7 +76,7 @@ class OpenTaskInSGCreateWebsocketsRequest(WebsocketsRequest):
                     "Task id %d cannot be found in Shotgun!" % (self._task_id,)
                 )
 
-             task_path = ShotgunEntityPath()
+            task_path = ShotgunEntityPath()
             task_path.set_project(task_data["project"]["id"])
             if task_data["entity"] is None:
                 task_path.set_primary_entity("Task", self._task_id)
@@ -107,10 +107,14 @@ class OpenTaskInSGCreateWebsocketsRequest(WebsocketsRequest):
 
                 version_path = ShotgunEntityPath()
                 version_path.set_project(version_data["project"]["id"])
-                version_path.set_primary_entity(
-                    version_data["entity"]["type"], version_data["entity"]["id"]
-                )
-                version_path.set_secondary_entity("Version", self._version_id)
+                if version_data["entity"] is None:
+                    version_path.set_primary_entity("Version", self._version_id)
+                else :
+                    version_path.set_primary_entity(
+                        version_data["entity"]["type"], version_data["entity"]["id"]
+                    )
+                    version_path.set_secondary_entity("Version", self._version_id)
+
                 version_path_str = version_path.as_string()
 
             # call out to Shotgun Create UI to focus on the task

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_task.py
@@ -76,15 +76,15 @@ class OpenTaskInSGCreateWebsocketsRequest(WebsocketsRequest):
                     "Task id %d cannot be found in Shotgun!" % (self._task_id,)
                 )
 
-            if task_data["entity"] is None:
-                raise RuntimeError("Tasks not linked to entities are not supported.")
-
-            task_path = ShotgunEntityPath()
+             task_path = ShotgunEntityPath()
             task_path.set_project(task_data["project"]["id"])
-            task_path.set_primary_entity(
-                task_data["entity"]["type"], task_data["entity"]["id"]
-            )
-            task_path.set_secondary_entity("Task", self._task_id)
+            if task_data["entity"] is None:
+                task_path.set_primary_entity("Task", self._task_id)
+            else:
+                task_path.set_primary_entity(
+                    task_data["entity"]["type"], task_data["entity"]["id"]
+                )
+                task_path.set_secondary_entity("Task", self._task_id)
 
             version_path_str = None
 

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_version_draft.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_version_draft.py
@@ -84,7 +84,6 @@ class OpenVersionDraftInSGCreateWebsocketsRequest(WebsocketsRequest):
 
             task_path = ShotgunEntityPath()
             task_path.set_project(task_data["project"]["id"])
-            
             if task_data["entity"] is None:
                 task_path.set_primary_entity("Task", self._task_id)
             else:

--- a/python/tk_desktop2/websockets/requests/sgc_actions/open_version_draft.py
+++ b/python/tk_desktop2/websockets/requests/sgc_actions/open_version_draft.py
@@ -82,15 +82,16 @@ class OpenVersionDraftInSGCreateWebsocketsRequest(WebsocketsRequest):
                     "Task id %d cannot be found in Shotgun!" % (self._task_id,)
                 )
 
-            if task_data["entity"] is None:
-                raise RuntimeError("Tasks not linked to entities are not supported.")
-
             task_path = ShotgunEntityPath()
             task_path.set_project(task_data["project"]["id"])
-            task_path.set_primary_entity(
-                task_data["entity"]["type"], task_data["entity"]["id"]
-            )
-            task_path.set_secondary_entity("Task", self._task_id)
+            
+            if task_data["entity"] is None:
+                task_path.set_primary_entity("Task", self._task_id)
+            else:
+                task_path.set_primary_entity(
+                    task_data["entity"]["type"], task_data["entity"]["id"]
+                )
+                task_path.set_secondary_entity("Task", self._task_id)
 
             # call out to Shotgun Create UI to set the media path
             self._bundle.toolkit_manager.emitOpenVersionDraft(


### PR DESCRIPTION
JIRA: SG-16214

This is already tested and merged in the Create codebase. I'm porting the change here so it doesn't disappear at the next plugin bundle cache generation. 