### PR TITLE
SG-34548 - Fixes JSON parsing for Python 3.9+

### DIFF
--- a/python/tk_desktop2/websockets/util.py
+++ b/python/tk_desktop2/websockets/util.py
@@ -36,10 +36,7 @@ def parse_json(payload):
     :param str payload: json payload
     :returns: Dictionary of values
     """
-    # data is sent as utf-8 across the wire
-    message_obj = json.loads(payload, encoding="utf-8")
-    message_obj = _convert(message_obj)
-    return message_obj
+    return _convert(json.loads(payload))
 
 
 def _json_date_handler(obj):


### PR DESCRIPTION
According to https://docs.python.org/3.9/library/json.html#json.loads..

Changed in version 3.9: The keyword argument encoding has been removed.